### PR TITLE
Path output standardization.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@kalarrs/serverless-local-dev-server",
-  "version": "1.0.0-beta.9",
+  "version": "1.0.0-beta.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kalarrs/serverless-local-dev-server",
-  "version": "1.0.0-beta.9",
+  "version": "1.0.0-beta.10",
   "engines": {
     "node": ">=6.0"
   },

--- a/src/Server.js
+++ b/src/Server.js
@@ -36,7 +36,7 @@ class Server {
       this.functions.forEach(func => {
         this.log(`${func.name}:`)
         func.endpoints.forEach(endpoint => {
-          this.log(`  ${endpoint.method} http://localhost:${port}${endpoint.path}`)
+          this.log(`  ${endpoint.method.toUpperCase()} http://localhost:${port}${endpoint.path}`)
         })
       })
       if (this.staticFolder) {


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "DieProduktMacher/serverless-local-dev-server" submits your change to ALL USERS OF THIS PLUGIN, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->