### PR TITLE
Added support for POST to send custom data to non http events like schedule and cloudWatch logs.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@kalarrs/serverless-local-dev-server",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kalarrs/serverless-local-dev-server",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "engines": {
     "node": ">=6.0"
   },

--- a/src/endpoints/CloudWatchLogEndpoint.js
+++ b/src/endpoints/CloudWatchLogEndpoint.js
@@ -8,11 +8,16 @@ class CloudWatchLogEndpoint extends Endpoint {
     if (typeof cloudWatchLogConfig === 'string') {
       cloudWatchLogConfig = {logGroup: cloudWatchLogConfig}
     }
-    this.method = 'GET'
+    this.method = cloudWatchLogConfig.method || 'GET'
     this.path = '/cloudwatch-logs/' + func.name + '/' + cloudWatchLogConfig.logGroup.replace(/^\//, '')
   }
 
   getLambdaEvent (request) {
+    if (request.method === 'POST') {
+      // Pass-through
+      return request.body
+    }
+
     return {
       awslogs: {
         data: 'H4sIAAAAAAAAAHWPwQqCQBCGX0Xm7EFtK+smZBEUgXoLCdMhFtKV3akI8d0bLYmibvPPN3wz00CJxmQnTO41whwWQRIctmEcB6sQbFC3CjW3XW8kxpOpP+OC22d1Wml1qZkQGtoMsScxaczKN3plG8zlaHIta5KqWsozoTYw3/djzwhpLwivWFGHGpAFe7DL68JlBUk+l7KSN7tCOEJ4M3/qOI49vMHj+zCKdlFqLaU2ZHV2a4Ct/an0/ivdX8oYc1UVX860fQDQiMdxRQEAAA=='

--- a/src/endpoints/ScheduleEndpoint.js
+++ b/src/endpoints/ScheduleEndpoint.js
@@ -35,6 +35,8 @@ class ScheduleEndpoint extends Endpoint {
   }
 
   getLambdaEvent (request) {
+    if (request.method === 'POST') return JSON.stringify(request.body, null, '  ')
+
     return this.input || {
       account: '123456789012',
       region: 'us-east-1',

--- a/src/endpoints/ScheduleEndpoint.js
+++ b/src/endpoints/ScheduleEndpoint.js
@@ -10,7 +10,7 @@ class ScheduleEndpoint extends Endpoint {
     if (typeof scheduleConfig === 'string') {
       scheduleConfig = {rate: scheduleConfig}
     }
-    this.method = 'GET'
+    this.method = scheduleConfig.method || 'GET'
     this.input = scheduleConfig.input || null
 
     let rateInEnglish = ''
@@ -35,7 +35,10 @@ class ScheduleEndpoint extends Endpoint {
   }
 
   getLambdaEvent (request) {
-    if (request.method === 'POST') return JSON.stringify(request.body, null, '  ')
+    if (request.method === 'POST') {
+      // Pass-through
+      return request.body
+    }
 
     return this.input || {
       account: '123456789012',

--- a/src/endpoints/get.js
+++ b/src/endpoints/get.js
@@ -22,11 +22,24 @@ module.exports = (func) => {
       !!mappings[_.type]
     // NOTE : Could filter out the the schedules that are not enabled here. Seems ghetto.
   ).reduce((arr, _) => {
-    if (_.type === 'schedule') {
+    if (_.type === 'schedule' || _.type === 'cloudwatchLog') {
+      let config
+      switch (_.type) {
+        case 'schedule':
+          config = typeof _.config === 'string'
+            ? {rate: _.config}
+            : {..._.config}
+          break
+        case 'cloudwatchLog':
+          config = typeof _.config === 'string'
+            ? {logGroup: _.config}
+            : {..._.config}
+          break
+      }
       arr.push({
         ..._,
         config: {
-          ..._.config,
+          ...config,
           method: 'POST',
           input: null
         }

--- a/src/endpoints/get.js
+++ b/src/endpoints/get.js
@@ -21,7 +21,20 @@ module.exports = (func) => {
   }).filter(_ =>
       !!mappings[_.type]
     // NOTE : Could filter out the the schedules that are not enabled here. Seems ghetto.
-  ).map(_ => {
+  ).reduce((arr, _) => {
+    if (_.type === 'schedule') {
+      arr.push({
+        ..._,
+        config: {
+          ..._.config,
+          method: 'POST',
+          input: null
+        }
+      })
+    }
+    arr.push(_)
+    return arr
+  }, []).map(_ => {
     let endpoint = new mappings[_.type](_.config, func)
     endpoint.type = _.type
     return endpoint

--- a/test/index.js
+++ b/test/index.js
@@ -53,6 +53,17 @@ describe('index.js', () => {
     return fetch(`http://localhost:${port}/cloudwatch-logs/${path}`)
   }
 
+  const sendCloudWatchLogsPostRequest = (port, path) => {
+    return fetch(`http://localhost:${port}/cloudwatch-logs/${path}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json'
+      },
+      body: '{"awslogs":{"data":"H4sIAAAAAAAAAHWPwQqCQBCGX0Xm7EFtK+smZBEUgXoLCdMhFtKV3akI8d0bLYmibvPPN3wz00CJxmQnTO41whwWQRIctmEcB6sQbFC3CjW3XW8kxpOpP+OC22d1Wml1qZkQGtoMsScxaczKN3plG8zlaHIta5KqWsozoTYw3/djzwhpLwivWFGHGpAFe7DL68JlBUk+l7KSN7tCOEJ4M3/qOI49vMHj+zCKdlFqLaU2ZHV2a4Ct/an0/ivdX8oYc1UVX860fQDQiMdxRQEAAA=="}}'
+    })
+  }
+
   const sendHttpPostRequest = (port, path) => {
     return fetch(`http://localhost:${port}/http/${path}`, {
       method: 'POST',
@@ -193,6 +204,9 @@ describe('index.js', () => {
         expect(result.status).equal(200)
       }),
       sendScheduleGetRequest(5005, 'MyScheduleCustomInput/rate-10-minute', {}).then(result => {
+        expect(result.status).equal(200)
+      }),
+      sendCloudWatchLogsPostRequest(5005, 'MyCloudWatchLogs/group1', {}).then(result => {
         expect(result.status).equal(200)
       }),
       sendCloudWatchLogsGetRequest(5005, 'MyCloudWatchLogs/group1', {}).then(result => {

--- a/test/index.js
+++ b/test/index.js
@@ -38,6 +38,17 @@ describe('index.js', () => {
     return fetch(`http://localhost:${port}/schedule/${path}`)
   }
 
+  const sendSchedulePostRequest = (port, path) => {
+    return fetch(`http://localhost:${port}/schedule/${path}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json'
+      },
+      body: '{"account":"123456789012","region":"us-east-1","detail":{},"detail-type":"Scheduled Event","source":"aws.events","time":"2018-10-11T22:12:48.774Z","id":"cdc73f9d-aea9-11e3-9d5a-835b769c0d9c","resources":["arn:aws:events:us-east-1:123456789012:rule/my-schedule"]}'
+    })
+  }
+
   const sendHttpPostRequest = (port, path) => {
     return fetch(`http://localhost:${port}/http/${path}`, {
       method: 'POST',
@@ -135,6 +146,9 @@ describe('index.js', () => {
       }),
       sendHttpPostRequest(5005, 'shorthand', {}).then(result => {
         expect(result.status).equal(204)
+      }),
+      sendSchedulePostRequest(5005, 'MySchedule/rate-1-day', {}).then(result => {
+        expect(result.status).equal(200)
       }),
       sendScheduleGetRequest(5005, 'MySchedule/rate-1-day', {}).then(result => {
         expect(result.status).equal(200)


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "DieProduktMacher/serverless-local-dev-server" submits your change to ALL USERS OF THIS PLUGIN, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->