### PR TITLE
fix output message

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@kalarrs/serverless-local-dev-server",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kalarrs/serverless-local-dev-server",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "engines": {
     "node": ">=6.0"
   },

--- a/src/Server.js
+++ b/src/Server.js
@@ -19,7 +19,7 @@ class Server {
   // Starts the server
   start (port) {
     if (this.functions.length === 0) {
-      this.log('No Lambdas with Alexa-Skill or HTTP events found')
+      this.log('No Lambda(s) with compatible events found')
       return
     }
     this.app = Express()


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "DieProduktMacher/serverless-local-dev-server" submits your change to ALL USERS OF THIS PLUGIN, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->